### PR TITLE
Configura a ordem das rotas do profissional

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -14,7 +14,7 @@ const routes: Routes = [
   { path: 'selecionaperfil', component: PerfilComponentComponent },
   { path: 'cadastrocliente', component: CadastroClienteComponent},
   { path: 'cadastroprofissional', component: CadastroProfissionalComponent},
-  { path: 'associarsalao', component: AssociacaoSalaoComponent},
+  { path: 'associarsalao/:id', component: AssociacaoSalaoComponent},
   { path: 'associarservicoprofissional/:id', component: AssociarServicosProfissionalComponent},
   { path: 'agendamento', component: AgendamentoComponent},
 ];

--- a/src/app/model/profissional.ts
+++ b/src/app/model/profissional.ts
@@ -1,7 +1,7 @@
 import { Salao } from './SalaoX';
 
 export class Profissional {
-  Id:Number;
+  id:Number;
   nome: string;
   telefone: string;
   email: string;

--- a/src/app/rest.service.ts
+++ b/src/app/rest.service.ts
@@ -67,7 +67,7 @@ export class RestService {
     )
   }
 
-  associateSaloes(profissionalId: string, saloes: Salao[]) {
+  associateSaloes(profissionalId: Number, saloes: Salao[]) {
     const url = `${environment.urlApi}/profissionais/${profissionalId}/saloes`;
     const requestBody = { saloes: saloes.map(salao => salao.id) };
     return this.http.put<any>(url, requestBody,

--- a/src/app/views/agendamento/agendamento.component.ts
+++ b/src/app/views/agendamento/agendamento.component.ts
@@ -78,9 +78,9 @@ export class AgendamentoComponent implements OnInit {
   ]
 
   profissionais:Profissional[] = [
-    { Id:1, nome:"Profissional_1", telefone:"111", email:"111", senha:'111', Saloes:this.saloes},
-    { Id:2, nome:"Profissional_2", telefone:"222", email:"222", senha:'222', Saloes:this.saloes2},
-    { Id:3, nome:"Profissional_3", telefone:"333", email:"333", senha:'333', Saloes:this.saloes3}
+    { id:1, nome:"Profissional_1", telefone:"111", email:"111", senha:'111', Saloes:this.saloes},
+    { id:2, nome:"Profissional_2", telefone:"222", email:"222", senha:'222', Saloes:this.saloes2},
+    { id:3, nome:"Profissional_3", telefone:"333", email:"333", senha:'333', Saloes:this.saloes3}
   ]
 
   // bairros:Salao[] = this.saloes.filter(
@@ -111,7 +111,7 @@ export class AgendamentoComponent implements OnInit {
   selecaoProfissional(event, Id) {
     //O IF abaixo é utilizado para reparar a falha da chamada do evento onSelectionChange, pois o mesmo realiza dua chamadas uma quando seleciona o novo valor e outra quando deseleciona o anterior
     if (event.source.selected) {
-        this.salaoFiltrado = this.profissionais.filter(s => s.Id === Id)[0].Saloes;
+        this.salaoFiltrado = this.profissionais.filter(s => s.id === Id)[0].Saloes;
         this.disableSelectSalao = false;
       }
   }

--- a/src/app/views/profissional/associacao-salao/associacao-salao.component.ts
+++ b/src/app/views/profissional/associacao-salao/associacao-salao.component.ts
@@ -1,5 +1,5 @@
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
-import { Component, ElementRef, ViewChild, Input } from '@angular/core';
+import { Component, ElementRef, ViewChild, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatAutocompleteSelectedEvent, MatAutocomplete } from '@angular/material/autocomplete';
 import { MatChipInputEvent } from '@angular/material/chips';
@@ -7,7 +7,8 @@ import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { RestService } from 'src/app/rest.service';
 import { Salao } from 'src/app/model/salao';
-
+import { ActivatedRoute, Router } from '@angular/router';
+import { Profissional } from "/home/lucas/projects/senac/my-barber-app/src/app/model/profissional";
 
 
 @Component({
@@ -15,7 +16,7 @@ import { Salao } from 'src/app/model/salao';
   templateUrl: './associacao-salao.component.html',
   styleUrls: ['./associacao-salao.component.scss']
 })
-export class AssociacaoSalaoComponent  {
+export class AssociacaoSalaoComponent implements OnInit {
 
   visible = true;
   selectable = true;
@@ -26,12 +27,14 @@ export class AssociacaoSalaoComponent  {
   filteredSaloes: Observable<Salao[]>;
   saloes: Salao[] = [];
   allSaloes: Salao[] = [];
+  profissional: Profissional
 
   @ViewChild('salaoInput', {static: false}) salaoInput: ElementRef<HTMLInputElement>;
   @ViewChild('auto', {static: false}) matAutocomplete: MatAutocomplete;
-  @Input() profissionalId: string = '1'
 
-  constructor(private api: RestService) {
+  constructor(private api: RestService, 
+              private route: ActivatedRoute,
+              private router: Router) {
 
     api.getSaloes().subscribe(resp => this.allSaloes = resp);
 
@@ -82,7 +85,20 @@ export class AssociacaoSalaoComponent  {
   }
 
   associar():void {
-    this.api.associateSaloes(this.profissionalId,  this.saloes).subscribe(console.table);
+    this.api.associateSaloes(this.profissional.id,  this.saloes).subscribe(console.table);
+
+    this.router.navigate(['/associarservicoprofissional', this.profissional.id]);
   }
 
+  ngOnInit() {
+    this.getProfissional(this.route.snapshot.params['id'])
+  }
+
+  getProfissional(id) {
+    this.api.getProfissional(id)
+      .subscribe(data => {
+        this.profissional = data;
+        console.log(this.profissional);
+      });
+  }
 }

--- a/src/app/views/profissional/associar-servicos-profissional/associar-servicos-profissional.component.ts.orig
+++ b/src/app/views/profissional/associar-servicos-profissional/associar-servicos-profissional.component.ts.orig
@@ -13,9 +13,13 @@ import { Observable } from 'rxjs';
 })
 export class AssociarServicosProfissionalComponent implements OnInit {
 
-  profissional: Profissional = { id: 0, nome: '', telefone: '', email: '', senha: '', Saloes: null};
+<<<<<<< Updated upstream
+  profissional: Profissional = { Id: 0, nome: '', telefone: '', email: '', senha: '', Saloes: null};
   dataSource: Servico[];
   displayedColumns: string[] = [ 'id','descricao', 'valor', 'categoria'];
+=======
+  profissional: Profissional = { id: 0, nome: '', telefone: '', email: '', senha: '', Saloes: null};
+>>>>>>> Stashed changes
 
   constructor(private router: Router, private route: ActivatedRoute, private api: RestService) { }
 

--- a/src/app/views/profissional/cadastro-profissional/cadastro-profissional.component.ts
+++ b/src/app/views/profissional/cadastro-profissional/cadastro-profissional.component.ts
@@ -35,7 +35,7 @@ export class CadastroProfissionalComponent implements OnInit {
     this.api.createProfissional(form)
       .subscribe(res => {
           const id = res['id'];
-          this.router.navigate(['/associarservicoprofissional', id]);
+          this.router.navigate(['/associarsalao', id]);
         }, (err) => {
           console.log(err);
         });


### PR DESCRIPTION
Este PR configura as rotas das telas de cadastro do profissional na seguinte ordem:

1 Informações pessoais
2 Associação de salões
3 Associação de serviços

Além disso corrigi um bug no mapeamento de modelo do profissional, onde o id estava como 'Id' com 'I' maiúsculo, e isso quebrava a serialização deste campo.